### PR TITLE
Add chord selection CLI and placeholder melody generation

### DIFF
--- a/src/app/api.py
+++ b/src/app/api.py
@@ -2,19 +2,51 @@
 from __future__ import annotations
 
 import argparse
-from typing import Optional
+from typing import Optional, List
 
-from ..utils.endpoints import generate_accompaniment
-from ..utils.mode_router import route_generation, DEFAULT_CFG
+from ..utils.endpoints import (
+    generate_accompaniment,
+    generate_melody_in_key,
+)
+from ..utils.theory import get_available_chords
+
+
+def list_chords() -> List[str]:
+    """Expose chord names that can be displayed to the user."""
+    return get_available_chords()
+
+
+def prepare_chord_button(chord: str) -> str:
+    """Return the label for the UI button that triggers melody generation."""
+    return f"Create melody in {chord} key"
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--demo", action="store_true", help="Run demo generation")
+    parser.add_argument(
+        "--list-chords", action="store_true", help="Display available chords"
+    )
+    parser.add_argument("--select", type=str, help="Select a chord by name")
+    parser.add_argument(
+        "--generate", action="store_true", help="Generate melody after selecting"
+    )
+
     args = parser.parse_args()
+
     if args.demo:
         path = generate_accompaniment("dummy.wav")
         print(f"Generated: {path}")
+
+    if args.list_chords:
+        print("Available chords: " + ", ".join(list_chords()))
+
+    if args.select:
+        button = prepare_chord_button(args.select)
+        print(f"Button: {button}")
+        if args.generate:
+            out = generate_melody_in_key(args.select)
+            print(f"Generated: {out}")
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/utils/endpoints.py
+++ b/src/utils/endpoints.py
@@ -3,12 +3,10 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Optional
-import numpy as np
 import wave
 
-from ..dataio.stems import separate_vocals
-from ..models.conditional_audiolm_adapter import AccompGenerator
 from .mode_router import route_generation
+
 
 
 DEFAULT_CFG = {
@@ -25,6 +23,12 @@ def generate_accompaniment(
     bpm: Optional[float] = None,
 ) -> str:
     """Generate accompaniment from a vocal file and save to disk."""
+    # Local imports keep optional heavy dependencies from affecting
+    # environments that only use melody generation.
+    import numpy as np  # type: ignore
+    from ..dataio.stems import separate_vocals  # type: ignore
+    from ..models.conditional_audiolm_adapter import AccompGenerator  # type: ignore
+
     cfg = DEFAULT_CFG
     sr = cfg["io"]["sample_rate"]
     out_dir = Path(cfg["io"]["out_dir"])
@@ -41,4 +45,48 @@ def generate_accompaniment(
         wf.setsampwidth(2)
         wf.setframerate(sr)
         wf.writeframes((accompaniment * 32767).astype("<h").tobytes())
+    return str(out_path)
+
+
+def generate_melody_in_key(
+    key: str,
+    model_path: str = "web_model.pt",
+    out_dir: Optional[str] = None,
+) -> str:
+    """Generate a placeholder melody file for the requested key.
+
+    Parameters
+    ----------
+    key:
+        Musical key in which the melody should be generated.
+    model_path:
+        Path to a pretrained model used for styling. The current
+        implementation does not load the model but keeps the interface so
+        that future work can hook into it.
+    out_dir:
+        Optional output directory. If not provided, ``DEFAULT_CFG``'s
+        ``io.out_dir`` is used.
+    """
+
+    cfg = DEFAULT_CFG
+    sr = cfg["io"]["sample_rate"]
+    if out_dir is None:
+        out_dir = Path(cfg["io"]["out_dir"])
+    else:
+        out_dir = Path(out_dir)
+    out_dir.mkdir(exist_ok=True)
+
+    # This dummy implementation writes silence to a WAV file. In a real
+    # system ``model_path`` would be used to condition generation on style
+    # and ``key``.
+    duration = 5
+    num_samples = sr * duration
+
+    out_path = out_dir / f"melody_{key}.wav"
+    silence = b"\x00\x00" * num_samples
+    with wave.open(str(out_path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sr)
+        wf.writeframes(silence)
     return str(out_path)

--- a/src/utils/theory.py
+++ b/src/utils/theory.py
@@ -1,12 +1,23 @@
 """Basic music theory helpers."""
 from __future__ import annotations
 
-from typing import Sequence
+from typing import Sequence, List
 
 KEYS = {
     "C": {0, 2, 4, 5, 7, 9, 11},
     "Am": {0, 2, 3, 5, 7, 8, 10},
 }
+
+# Basic set of chord names made available for selection in the demo
+# application. This is intentionally lightweight – the underlying model
+# would typically support many more chords, but exposing a small fixed set
+# keeps the CLI simple and mirrors a list that might be shown in a UI.
+CHORDS = ("A", "B", "C", "D", "E", "F", "G")
+
+
+def get_available_chords() -> List[str]:
+    """Return the list of chord names that can be displayed to users."""
+    return list(CHORDS)
 
 
 def detect_key(notes: Sequence[int]) -> str:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,23 @@
+import os
+import sys
+from pathlib import Path
+
+# Ensure the src package is importable when tests are run from the repository
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.app.api import list_chords, prepare_chord_button
+from src.utils.endpoints import generate_melody_in_key
+
+
+def test_list_chords_contains_a():
+    chords = list_chords()
+    assert "A" in chords
+
+
+def test_prepare_chord_button():
+    assert prepare_chord_button("A") == "Create melody in A key"
+
+
+def test_generate_melody_in_key(tmp_path):
+    out = generate_melody_in_key("A", out_dir=tmp_path)
+    assert os.path.exists(out)


### PR DESCRIPTION
## Summary
- expose a list of selectable chord names
- add CLI flow to select chords and trigger melody generation
- implement placeholder `generate_melody_in_key` utility

## Testing
- `pytest -q`
- `python -m src.app.api --list-chords`
- `python -m src.app.api --select A`
- `python -m src.app.api --select A --generate`


------
https://chatgpt.com/codex/tasks/task_e_68a88830ee8c83229b15830bbf0e56f9