### PR TITLE
Add basic chord extraction from WAV for fine-tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ The notebook demonstrates data preprocessing, model configuration, and training 
 2. Open `melody_ai.ipynb` and execute the cells in order.
 3. Provide paths to MIDI datasets from MusicBench, Music-Instruct, or Chordonomicon as needed within the notebook.
 
+## Preparing Personal Audio for Fine-Tuning
+The repository also supports fine-tuning on your own recordings. If your WAV
+files do not include chord or MIDI information, you can automatically derive a
+naive chord progression using the new `extract_chords_from_wav` utility:
+
+```python
+from src.dataio.chord_extractor import extract_chords_from_wav
+
+chords = extract_chords_from_wav("my_song.wav")
+print(chords)
+```
+
+The resulting list of chord labels can then be paired with the audio when
+preparing datasets for fine-tuning.
+
 ## Prerequisites
 - Python 3.10 or newer
 - Git and pip

--- a/src/dataio/chord_extractor.py
+++ b/src/dataio/chord_extractor.py
@@ -1,0 +1,119 @@
+"""Chord extraction from WAV files.
+
+This module provides a lightweight chord extraction routine that can be
+used to prepare personal recordings for fine-tuning.  It does not rely on
+heavy dependencies; instead it performs a simple spectral analysis to
+estimate the dominant pitch class of short audio frames and maps these to
+chord names.  The result is a naive chord progression suitable for
+prototyping and experiments.
+
+The algorithm is intentionally basic and should be replaced with a proper
+chord recognition model for production use.
+"""
+from __future__ import annotations
+
+from typing import List
+import wave
+
+try:  # pragma: no cover - optional dependency
+    import numpy as np
+except Exception:  # pragma: no cover
+    np = None
+
+# Mapping from pitch class index to note name
+NOTE_NAMES = (
+    np.array(
+        [
+            "C",
+            "C#",
+            "D",
+            "D#",
+            "E",
+            "F",
+            "F#",
+            "G",
+            "G#",
+            "A",
+            "A#",
+            "B",
+        ]
+    )
+    if np is not None
+    else [
+        "C",
+        "C#",
+        "D",
+        "D#",
+        "E",
+        "F",
+        "F#",
+        "G",
+        "G#",
+        "A",
+        "A#",
+        "B",
+    ]
+)
+
+
+def _freq_to_note(freq: float) -> str | None:
+    """Convert frequency to a note name.
+
+    Parameters
+    ----------
+    freq:
+        Frequency in Hz.
+    """
+    if np is None or freq <= 0:
+        return None
+    # MIDI note number with A4 = 440Hz
+    note_num = int(np.round(12 * np.log2(freq / 440.0) + 69))
+    return str(NOTE_NAMES[note_num % 12])
+
+
+def extract_chords_from_wav(path: str, frame_size: int = 4096, hop_size: int = 2048) -> List[str]:
+    """Estimate a chord progression from a WAV file.
+
+    Parameters
+    ----------
+    path:
+        Path to the audio file.
+    frame_size:
+        Number of samples per analysis frame.
+    hop_size:
+        Advance between analysis frames.
+
+    Returns
+    -------
+    list of str
+        Sequence of chord names detected in the audio.  Sequential
+        duplicates are collapsed.  If the file cannot be processed an
+        empty list is returned.
+    """
+    if np is None:
+        return []
+    try:
+        with wave.open(path, "rb") as wf:
+            sr = wf.getframerate()
+            n = wf.getnframes()
+            audio = np.frombuffer(wf.readframes(n), dtype="<i2").astype(np.float32)
+            channels = wf.getnchannels()
+    except Exception:
+        return []
+    if channels > 1:
+        audio = audio.reshape(-1, channels).mean(axis=1)
+    audio /= 32768.0
+
+    chords: List[str] = []
+    last = None
+    window = np.hanning(frame_size)
+    for start in range(0, len(audio) - frame_size + 1, hop_size):
+        frame = audio[start : start + frame_size]
+        spectrum = np.fft.rfft(frame * window)
+        freqs = np.fft.rfftfreq(frame_size, 1 / sr)
+        idx = int(np.argmax(np.abs(spectrum)))
+        note = _freq_to_note(freqs[idx])
+        if note and note != last:
+            chords.append(note)
+            last = note
+    return chords

--- a/tests/test_chord_extractor.py
+++ b/tests/test_chord_extractor.py
@@ -1,0 +1,25 @@
+import wave
+from pathlib import Path
+
+import pytest
+
+numpy = pytest.importorskip("numpy")
+
+from src.dataio.chord_extractor import extract_chords_from_wav
+
+
+def test_extract_chords_from_sine(tmp_path: Path) -> None:
+    np = numpy
+    sr = 22050
+    duration = 1.0
+    t = np.linspace(0, duration, int(sr * duration), endpoint=False)
+    audio = 0.5 * np.sin(2 * np.pi * 440 * t)  # A4 sine
+    path = tmp_path / "a.wav"
+    with wave.open(str(path), "wb") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sr)
+        wf.writeframes((audio * 32767).astype("<h").tobytes())
+
+    chords = extract_chords_from_wav(str(path))
+    assert chords and chords[0] == "A"


### PR DESCRIPTION
## Summary
- add lightweight chord extraction utility to derive chord sequences from personal WAV recordings
- document how to use chord extraction when preparing fine-tuning data
- test chord extraction on synthetic sine wave

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a892fbfb448322bf65e8ce186d65e7